### PR TITLE
Fixing core dump - yes/no?

### DIFF
--- a/regression/cbmc/String_Abstraction17/test.desc
+++ b/regression/cbmc/String_Abstraction17/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 strcpy-no-decl.c
 --string-abstraction --validate-goto-model
 Condition: strlen type inconsistency

--- a/regression/invariants/invariant-failure/test.desc
+++ b/regression/invariants/invariant-failure/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 dummy_parameter.c
 string
 ^EXIT=(0|127|134|137)$

--- a/regression/invariants/invariant-failure10/test.desc
+++ b/regression/invariants/invariant-failure10/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 dummy_parameter.c
 unreachable-structured
 ^EXIT=(0|127|134|137)$

--- a/regression/invariants/invariant-failure11/test.desc
+++ b/regression/invariants/invariant-failure11/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 dummy_parameter.c
 data-invariant-string
 ^EXIT=(0|127|134|137)$

--- a/regression/invariants/invariant-failure12/test.desc
+++ b/regression/invariants/invariant-failure12/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 dummy_parameter.c
 data-invariant-structured
 ^EXIT=(0|127|134|137)$

--- a/regression/invariants/invariant-failure13/test.desc
+++ b/regression/invariants/invariant-failure13/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 dummy_parameter.c
 irep
 ^EXIT=(0|127|134|137)$

--- a/regression/invariants/invariant-failure14/test.desc
+++ b/regression/invariants/invariant-failure14/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 dummy_parameter.c
 invariant-diagnostics
 ^EXIT=(0|127|134|137)$

--- a/regression/invariants/invariant-failure15/test.desc
+++ b/regression/invariants/invariant-failure15/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 dummy_parameter.c
 precondition-diagnostics
 ^EXIT=(0|127|134|137)$

--- a/regression/invariants/invariant-failure16/test.desc
+++ b/regression/invariants/invariant-failure16/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 dummy_parameter.c
 postcondition-diagnostics
 ^EXIT=(0|127|134|137)$

--- a/regression/invariants/invariant-failure17/test.desc
+++ b/regression/invariants/invariant-failure17/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 dummy_parameter.c
 check-return-diagnostics
 ^EXIT=(0|127|134|137)$

--- a/regression/invariants/invariant-failure18/test.desc
+++ b/regression/invariants/invariant-failure18/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 dummy_parameter.c
 data-invariant-diagnostics
 ^EXIT=(0|127|134|137)$

--- a/regression/invariants/invariant-failure19/test.desc
+++ b/regression/invariants/invariant-failure19/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 dummy_parameter.c
 invariant-with-lots-of-diagnostics
 ^EXIT=(0|127|134|137)$

--- a/regression/invariants/invariant-failure2/test.desc
+++ b/regression/invariants/invariant-failure2/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 dummy_parameter.c
 structured
 ^EXIT=(0|127|134|137)$

--- a/regression/invariants/invariant-failure20/test.desc
+++ b/regression/invariants/invariant-failure20/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 dummy_parameter.c
 invariant-with-custom-diagnostics
 ^EXIT=(0|127|134|137)$

--- a/regression/invariants/invariant-failure3/test.desc
+++ b/regression/invariants/invariant-failure3/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 dummy_parameter.c
 precondition-string
 ^EXIT=(0|127|134|137)$

--- a/regression/invariants/invariant-failure4/test.desc
+++ b/regression/invariants/invariant-failure4/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 dummy_parameter.c
 precondition-structured
 ^EXIT=(0|127|134|137)$

--- a/regression/invariants/invariant-failure5/test.desc
+++ b/regression/invariants/invariant-failure5/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 dummy_parameter.c
 postcondition-string
 ^EXIT=(0|127|134|137)$

--- a/regression/invariants/invariant-failure6/test.desc
+++ b/regression/invariants/invariant-failure6/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 dummy_parameter.c
 postcondition-structured
 ^EXIT=(0|127|134|137)$

--- a/regression/invariants/invariant-failure7/test.desc
+++ b/regression/invariants/invariant-failure7/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 dummy_parameter.c
 check-return-string
 ^EXIT=(0|127|134|137)$

--- a/regression/invariants/invariant-failure8/test.desc
+++ b/regression/invariants/invariant-failure8/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 dummy_parameter.c
 check-return-structured
 ^EXIT=(0|127|134|137)$

--- a/regression/invariants/invariant-failure9/test.desc
+++ b/regression/invariants/invariant-failure9/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 dummy_parameter.c
 unreachable-string
 ^EXIT=(0|127|134|137)$

--- a/regression/invariants/invariant-irep-diagnostic/test.desc
+++ b/regression/invariants/invariant-irep-diagnostic/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 dummy_parameter.c
 invariant-with-irep-diagnostics
 ^EXIT=(0|127|134|137)$


### PR DESCRIPTION
Encountered some core dump in regression tests. Attached below screenshots and full output files of before and after.

Checked them also on branch christine.dev (it's the one **before** we changed anything in the code) and they were already there as "Aborted" under status "OK".
Should these changes here (from CORE to KNOWNBUG) be applied or is it supposed to show core dump and these tests check that it does catch the core dump and it should be kept under CORE?

Screenshot and output file **before** the changes:
![image](https://github.com/user-attachments/assets/11199462-7947-4ba6-94c4-e00b595a9be8)
[output.txt](https://github.com/user-attachments/files/18303360/output.txt)
 
 Screenshot and an outpt file **after** the changes:
![image](https://github.com/user-attachments/assets/6a9f148d-ba4d-4f14-bca6-c62fed91a0dc)
[output_after_changing_CORE_to_KNOWNBUG.log](https://github.com/user-attachments/files/18303589/output_after_changing_CORE_to_KNOWNBUG.log)
