### PR TITLE
Added instruction done=1 to the new goto program

### DIFF
--- a/src/goto-programs/remove_function_pointers.cpp
+++ b/src/goto-programs/remove_function_pointers.cpp
@@ -521,16 +521,11 @@ void remove_function_pointer_mine(
 {
   const exprt &function = target->call_function();
   const exprt &pointer = to_dereference_expr(function).pointer();
-  
-  // the final target is a skip
-  // goto_programt final_skip;
- goto_programt new_code;
+
+  goto_programt new_code;
   goto_programt::targett t_final = new_code.add(goto_programt::make_skip());
   // build the calls and gotos
 
-  // goto_programt new_code_calls;
-  // goto_programt new_code_gotos;
- 
   auto previous_if = t_final;
   for(const auto &fun : functions)
   {
@@ -546,9 +541,12 @@ void remove_function_pointer_mine(
 
     auto previous_call = new_code.insert_before(previous_if, goto_programt::make_function_call(new_call));
     new_code.destructive_insert(previous_if, tmp);
+    
+    // Create the assignment `done = 1`
+    symbol_exprt done_expr("done", typet(bool_typet())); 
+    constant_exprt one_expr(irep_idt("1"),signed_int_type());
 
-    // goto final
-    //new_code.add(goto_programt::make_goto(t_final, true_exprt()));
+    new_code.insert_before(previous_if, goto_programt::make_assignment(code_assignt(done_expr, one_expr)));
 
     // goto to call
     const address_of_exprt address_of(fun, pointer_type(fun.type()));

--- a/src/goto-programs/remove_function_pointers.cpp
+++ b/src/goto-programs/remove_function_pointers.cpp
@@ -527,8 +527,10 @@ void remove_function_pointer_mine(
   
   // build the calls and gotos
   
-  // Create the assignment `done = 1`
-  symbol_exprt done_expr("done", typet(bool_typet())); 
+  // Intialize the assignment instruction `done = false`
+  symbol_exprt done_expr("done", typet(bool_typet()));
+  goto_programt::make_assignment(code_assignt(done_expr, false_exprt()));
+   
   auto previous_if = t_final;
   for(const auto &fun : functions)
   {
@@ -544,11 +546,8 @@ void remove_function_pointer_mine(
 
     auto previous_call = new_code.insert_before(previous_if, goto_programt::make_function_call(new_call));
     new_code.destructive_insert(previous_if, tmp);
-    
-    // Create the assignment tbe one for `done = 1`
-    constant_exprt one_expr(irep_idt("1"),signed_int_type());
-
-    new_code.insert_before(previous_if, goto_programt::make_assignment(code_assignt(done_expr, one_expr)));
+      
+    new_code.insert_before(previous_if, goto_programt::make_assignment(code_assignt(done_expr, true_exprt())));//this line is what's causing the dump core in 'cbmc fp.c --choose-first-candidate --pointer-check'
 
     // goto to call
     const address_of_exprt address_of(fun, pointer_type(fun.type()));
@@ -569,6 +568,7 @@ void remove_function_pointer_mine(
     t->source_location_nonconst().set_comment(
       function_pointer_assertion_comment(functions));
   }
+
   new_code.add(goto_programt::make_assumption(done_expr));
 
   // set locations


### PR DESCRIPTION
I compare it to branchFixingCoreDumpInString_Abstration because I merged the changes there of CORE and KNOWNBUG to AddAssignmentInstructionDone branch and didn't want the changes there to appear in this PR since they are not sure to be true yet. Once we know what about those changes I'll merge the changes to collaboration.dev.

Added done = 1 instruction (and deleted extra comments).
checked the oputput in three cases:
1. when tmp is added to all candidate (1 inst' in tmp)
2. when tmp is added to one cadidate
3. when tmp is added to none (no inst' in tmp) 

Attached below screenshots for all cases accordingly.

Ran regression without the problematic ones (that appear on branchFixingCoreDumpInString_Abstration) and unit test, all passed.

1.
![image](https://github.com/user-attachments/assets/d82626b7-4a76-4bb2-8f81-b7b7098fb214)

2.
![image](https://github.com/user-attachments/assets/ae1e4658-fa10-433b-8c03-3a09fb28d147)

3.
![image](https://github.com/user-attachments/assets/f0159c83-c44e-4168-8c54-558c4c72cc46)

Also added the assert(done) and assume(done):
![image](https://github.com/user-attachments/assets/7583a83a-820e-4183-95fa-fe0dbfe2a981)
