### PR TITLE
Addittion of "done = true", assumption(done) and assertion (done)

### DIFF
--- a/src/goto-programs/remove_function_pointers.cpp
+++ b/src/goto-programs/remove_function_pointers.cpp
@@ -521,16 +521,11 @@ void remove_function_pointer_mine(
 {
   const exprt &function = target->call_function();
   const exprt &pointer = to_dereference_expr(function).pointer();
-  
-  // the final target is a skip
-  // goto_programt final_skip;
- goto_programt new_code;
+
+  goto_programt new_code;
   goto_programt::targett t_final = new_code.add(goto_programt::make_skip());
   // build the calls and gotos
 
-  // goto_programt new_code_calls;
-  // goto_programt new_code_gotos;
- 
   auto previous_if = t_final;
   for(const auto &fun : functions)
   {
@@ -546,9 +541,12 @@ void remove_function_pointer_mine(
 
     auto previous_call = new_code.insert_before(previous_if, goto_programt::make_function_call(new_call));
     new_code.destructive_insert(previous_if, tmp);
+    
+    // Create the assignment `done = 1`
+    symbol_exprt done_expr("done", typet(bool_typet())); 
+    constant_exprt one_expr(irep_idt("1"),signed_int_type());
 
-    // goto final
-    //new_code.add(goto_programt::make_goto(t_final, true_exprt()));
+    new_code.insert_before(previous_if, goto_programt::make_assignment(code_assignt(done_expr, one_expr)));
 
     // goto to call
     const address_of_exprt address_of(fun, pointer_type(fun.type()));

--- a/src/goto-programs/remove_function_pointers.cpp
+++ b/src/goto-programs/remove_function_pointers.cpp
@@ -527,8 +527,10 @@ void remove_function_pointer_mine(
   
   // build the calls and gotos
   
-  // Create the assignment `done = 1`
-  symbol_exprt done_expr("done", typet(bool_typet())); 
+  // Intialize the assignment instruction `done = false`
+  symbol_exprt done_expr("done", typet(bool_typet()));
+  goto_programt::make_assignment(code_assignt(done_expr, false_exprt()));
+   
   auto previous_if = t_final;
   for(const auto &fun : functions)
   {
@@ -544,11 +546,8 @@ void remove_function_pointer_mine(
 
     auto previous_call = new_code.insert_before(previous_if, goto_programt::make_function_call(new_call));
     new_code.destructive_insert(previous_if, tmp);
-    
-    // Create the assignment tbe one for `done = 1`
-    constant_exprt one_expr(irep_idt("1"),signed_int_type());
-
-    new_code.insert_before(previous_if, goto_programt::make_assignment(code_assignt(done_expr, one_expr)));
+      
+    new_code.insert_before(previous_if, goto_programt::make_assignment(code_assignt(done_expr, true_exprt())));//this line is what's causing the dump core in 'cbmc fp.c --choose-first-candidate --pointer-check'
 
     // goto to call
     const address_of_exprt address_of(fun, pointer_type(fun.type()));
@@ -569,6 +568,7 @@ void remove_function_pointer_mine(
     t->source_location_nonconst().set_comment(
       function_pointer_assertion_comment(functions));
   }
+
   new_code.add(goto_programt::make_assumption(done_expr));
 
   // set locations


### PR DESCRIPTION
changed the type of rhs for done to boolean instead of int. 
Created 'done=false' at first so we can assert if it's true after the for loop so we can make sure it chose a candidate.
marked in a comment line 550 as the one that is causing the dump core so we can check it "new_code.insert_before(previous_if, goto_programt::make_assignment(code_assignt(done_expr, true_exprt())));"

Opened a new PR since the previous one was against branch "FixingCoreDumpInString_Abstraction17/test.desc" and it was already merged to collaboration.dev and wasn't able to change the comparison of the branches.

Output when |tmp|=0:
![image](https://github.com/user-attachments/assets/eee25857-79d7-441a-8a0e-b09924d652ef)

Output when |tmp|=1:
![image](https://github.com/user-attachments/assets/6624a251-480b-4231-864d-d68338c30570)
